### PR TITLE
Extra details on what reports to take to the endo

### DIFF
--- a/docs/how-to/endo.md
+++ b/docs/how-to/endo.md
@@ -6,11 +6,55 @@ Since using Loop often requires people to secure access to pump supplies that th
 
 Most often the important aspects that need discussion are:
 
-* Loop will revert to normal pump use, within a maximum of 30 minutes, in the event of Loop failure.  What happens during failure of the system is the most common concern your health care provider will likely have when initially learning about the system.</br>
-* Loop depends on your basal rate, ISF, and carbohydrate ratio settings, just like traditional pump therapy. The conversations will not need to change regarding the evaluation and adequacy of those settings.</br>
-* Duration of insulin action is automatically set to 6-hours for the rapid-acting insulin models built into Loop, matching published data for those insulins. The settings in the pump for duration of insulin action are not used by Loop.</br>
-* Reasonable values for the suspend threshold and maximum basal rate should be discussed.  These two settings are not part of normal pump therapy and should be discussed with your endocrinologist. Typically to start Looping, setting the maximum basal rate not much above your highest scheduled basal rate is an excellent way to get used to Loop and safely double-check that your settings (ISF, carbohydrate ratio, and basal schedule) are reasonably accurate.  As you gain experience and confirm your settings, raising the maximum basal rate can help Loop become more effective to correct rising blood glucose more quickly.</br>
-* Develop a plan for how you will be providing Loop data to your health care provider in advance.  Ask what information they would like to review so that you can have reports ready at each appointment. The usual downlaod of a Medtronic pump or Omnipod PDM will not be sufficient for many clinics once you start Loop.  Instead, you may wish to discuss Nightscout or Tidepool data reports to provide the information those downloads would have otherwise provided.</br>
+* Loop will revert to normal pump use, within a maximum of 30 minutes, in the event of Loop failure.  What happens during failure of the system is the most common concern your health care provider will likely have when initially learning about the system.</br></br>
+* Loop depends on your basal rate, ISF, and carbohydrate ratio settings, just like traditional pump therapy. The conversations will not need to change regarding the evaluation and adequacy of those settings.</br></br>
+* Duration of insulin action is automatically set to 6-hours for the rapid-acting insulin models built into Loop, matching published data for those insulins. The settings in the pump for duration of insulin action are not used by Loop.</br></br>
+* Reasonable values for the suspend threshold and maximum basal rate should be discussed.  These two settings are not part of normal pump therapy and should be discussed with your endocrinologist. Typically to start Looping, setting the maximum basal rate not much above your highest scheduled basal rate is an excellent way to get used to Loop and safely double-check that your settings (ISF, carbohydrate ratio, and basal schedule) are reasonably accurate.  As you gain experience and confirm your settings, raising the maximum basal rate can help Loop become more effective to correct rising blood glucose more quickly.</br></br>
+* Develop a plan for how you will be providing Loop data to your health care provider in advance.  Ask what information they would like to review so that you can have reports ready at each appointment. The usual downlaod of a Medtronic pump or Omnipod PDM will not be sufficient for many clinics once you start Loop.  Instead, you may wish to discuss Nightscout or Tidepool data reports to provide the information those downloads would have otherwise provided.</br></br>
 * Develop a plan for how you will deal with pump failure. Many health care professionals will cite the age and out-of-warranty aspects as concerns for Loop users. Having a clear plan, in advance, for how to deal with possible pump failure will help with that concern. The two most obvious steps would be to have a backup pump available and an active prescription for long-acting insulin. A gentle reminder to the clinic that even in-warranty pumps can fail also helps frame the conversation regarding the need to always be prepared, looping or not.
 
+# What data does the endo want to see?
 
+A very common question once looping is “what reports should I bring to the endocrinologist?”  Fortunately, there are a number of reporting tools that you can use to make this process easier.  Each of the tools below provide reports you can share with your endo.  Click each one to take you to the details on how to set up / use.
+
+* [Tidepool](https://kdisimone.github.io/looptips/data/tidepool/)
+* [Nightscout reports](https://kdisimone.github.io/looptips/data/nightscout/#nightscout-reports)
+* Nightscout Reporter (set up page coming soon)
+* Dexcom Clarity (set up page coming soon)
+* [Perceptus Dash](https://kdisimone.github.io/looptips/data/glucodyn/#dash)
+
+All of these tools provide reports of various kinds but the real question is what are endocrinologists looking for?  While that can always vary, and it’s best to check with your specific endo on what they are looking for, in most cases they are interested in many of the following details:
+
+* **CGM data**
+  * Average Blood Glucose
+  * Time in range, % above range, % below range
+    * Recommended range (e.g. 70-180)
+    * Personal range (the individual goal range you are striving for)
+  * Standard Deviation (SD)
+  * Coefficient of Variation (CV)
+  * Glucose Percentile Graph (average BG trends)
+  * Daily and/or weekly glucose graphs<br><br>
+* **Pump data**
+  * Current settings (basal rates, insulin to carb ratio, insulin sensitivity factor, insulin duration)
+  * Average insulin units delivered per day
+  * Percentage of basal versus bolus insulin
+
+# Which reporting tools provide what data?
+
+If your endo uses **Tidepool**, that’s likely the easiest answer of all the tools.  You can authorize their access and they can review the details at their own pace on their own time.  If you want to bring printed out results, **Nightscout Reporter** might be the most simple yet comprehensive option.  That said, work with your endogrinologist on what data they'd like to see and use the tools listed here to create a packet of information for your collaborative conversation.
+
+To understand what's available in each tool, check out the summary table below.
+
+| Data | Tidepool | Nightscout Reports | Nightscout Reporter | Dexcom Clarity | Perceptus Dash| 
+| --- | :---: | :---: | :---: | :---: | :---: | 
+| Average Blood Glucose |x|x|x|x|x|
+| Time in range, % above/below |x|x|x|x|x|
+|---Standard Range| | |x| |x|
+|---Personal range |x|x|x|x| |
+| Standard Deviation |x|x|x|x| |
+| Coefficient of Variation |x|x|x|x| |
+| Glucose Percentile Graph |x|x|x|x| |
+| Daily/weekly glucose graphs |x|x|x|x| |
+| Current pump settings  |x|x|x| | |
+| Average insulin delivered |x|x|x| | |
+| % basal versus bolus |x|x|x| | |


### PR DESCRIPTION
I've seen a lot of questions on Looped about what data, what reports, etc should I bring to the endo.  I've added additional data to the "talk to the endo" page as a way to help provide a little more context.  It would be good to add a set up page for Nightscout Reporter as well as Dexcom Clarity.  I'm happy to write the content and add images to create those pages if there's interest.  Feel free to keep, edit, and delete any of the attached as you see fit.