### PR TITLE
⚰️  Remove unused mathjax.js include

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,6 @@ markdown_extensions:
         toc_depth: 3
         title: Headers on this Page
 extra_javascript:
-    - javascripts/mathjax.js
     - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 


### PR DESCRIPTION
This PR is the counterpart of Loopdocs's [PR#595](https://github.com/LoopKit/loopdocs/pull/595).

It removes the reference to the non-existent `docs/javascripts/mathjax.js` file (not used nor needed).

This file may prove useful one day should we need to:
- make an additional configuration (not used today as we use the default one)
- use [instant loading](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading) (ie. Single Page Application) that we do not use