### PR TITLE
👷 Fix `publish.yml` deprecation warnings: Node 12 GH actions  + set-output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -21,7 +23,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: mkdocs build
 
-      - uses: JamesIves/github-pages-deploy-action@v4.2.5
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          BRANCH: gh-pages
-          FOLDER: site
+          branch: gh-pages
+          folder: site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt


### PR DESCRIPTION
⚠️ Running the github action [publish.yml](https://github.com/LoopKit/looptips/blob/6c275182c15e351efd6bda573e819cc196d378b5/.github/workflows/publish.yml#L24) generates the following deprecation warnings:

- **`Node.js 12 actions are deprecated`**
  > Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16:
JamesIves/github-pages-deploy-action@v4.2.5. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
- **`The set-output command is deprecated and will be disabled soon`**
  > The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

💚 The **fix** consists in **upgrading** 2 **Github Actions** and giving write access to the Github action script:
- Upgrade `actions/setup-python` Github Action to v4 from v3
- Upgrade `JamesIves/github-pages-deploy-action` Github Action to v4 latest from v4.2.5
  - Remove `set-output command is deprecated`
    See: https://github.com/JamesIves/github-pages-deploy-action/issues/1241
  - Remove `Node.js 12 actions are deprecated`
  - Add content write permission to `publish.yml` Github Action (read-only by default)
    See: https://github.com/JamesIves/github-pages-deploy-action/issues/1285