### PR TITLE
➕ Add plugin mkdocs-htmlproofer-plugin to check for broken links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,14 @@ extra_css:
     - css/extra.css
     - css/primary-color.css
 
-    
+plugins:
+    - search
+    - htmlproofer:
+        enabled: !ENV [CHECK_BROKEN_LINKS, False]
+        raise_error_after_finish: true
+
+use_directory_urls: !ENV [CHECK_BROKEN_LINKS, True]
+
 markdown_extensions:
     - meta
     - abbr
@@ -40,6 +47,7 @@ markdown_extensions:
         permalink_title: Anchor link to this Header on this Page
         toc_depth: 3
         title: Headers on this Page
+
 extra_javascript:
     - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.12.2
 certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3
@@ -9,6 +10,7 @@ Markdown==3.3.7
 MarkupSafe==2.1.2
 mergedeep==1.3.4
 mkdocs==1.4.3
+mkdocs-htmlproofer-plugin==0.13.1
 mkdocs-material==9.1.13
 mkdocs-material-extensions==1.1.1
 packaging==23.1
@@ -20,5 +22,6 @@ pyyaml_env_tag==0.1
 regex==2023.5.5
 requests==2.31.0
 six==1.16.0
+soupsieve==2.4.1
 urllib3==2.0.2
 watchdog==3.0.0


### PR DESCRIPTION
The `mkdocs-htmlproofer-plugin` find broken links.

See: https://github.com/manuzhang/mkdocs-htmlproofer-plugin

Update your project dependencies:
```shell
python -m pip install -r requirements.txt  
```

To check for broken links in your local repository:
```shell
CHECK_BROKEN_LINKS=true mkdocs serve
```