### PR TITLE
⬆️  Upgrade Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Babel==2.13.0
 beautifulsoup4==4.12.2
 certifi==2023.7.22
 charset-normalizer==3.1.0
@@ -9,13 +10,16 @@ Jinja2==3.1.2
 Markdown==3.3.7
 MarkupSafe==2.1.2
 mergedeep==1.3.4
-mkdocs==1.4.3
-mkdocs-htmlproofer-plugin==0.13.1
-mkdocs-material==9.1.13
-mkdocs-material-extensions==1.1.1
+mkdocs==1.5.3
+mkdocs-htmlproofer-plugin==1.0.0
+mkdocs-material==9.4.4
+mkdocs-material-extensions==1.2
 packaging==23.1
-Pygments==2.15.1
-pymdown-extensions==10.0.1
+paginate==0.5.6
+pathspec==0.11.2
+platformdirs==3.11.0
+Pygments==2.16.1
+pymdown-extensions==10.3
 python-dateutil==2.8.2
 PyYAML==6.0
 pyyaml_env_tag==0.1
@@ -23,5 +27,5 @@ regex==2023.5.5
 requests==2.31.0
 six==1.16.0
 soupsieve==2.4.1
-urllib3==2.0.2
+urllib3==2.0.6
 watchdog==3.0.0


### PR DESCRIPTION
This PR upgrades the project's dependencies:

- `mkdocs` from 1.4.3 to 1.5.3 (**major** version upgrade)
- `mkdocs-material` from 9.1.13 to 9.4.3
- `mkdocs-htmlproofer-plugin` from 0.13.1 to 1.0.0
- `mkdocs-material-extensions` from 1.1.1 to 1.2
- `Pygments` from 2.15.0 to 2.16.1
- `pymdown-extensions` from 10.0.1 to 10.3
- `urllib3` from 1.26.14 to 2.0.6 (**fixes dependabot 8**)
- other dependencies have been pulled in:
  - `paginate`
  - `pathspec`
  - `platformdirs`

It also fixes [Security vulnerability dependabot#8](https://github.com/LoopKit/looptips/security/dependabot/8)
