### PR TITLE
⬆️ Upgrade dependencies (`PyYAML` and `mkdocs-material`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ platformdirs==3.11.0
 Pygments==2.16.1
 pymdown-extensions==10.3
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 pyyaml_env_tag==0.1
 regex==2023.5.5
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ MarkupSafe==2.1.2
 mergedeep==1.3.4
 mkdocs==1.5.3
 mkdocs-htmlproofer-plugin==1.0.0
-mkdocs-material==9.4.4
+mkdocs-material==9.4.6
 mkdocs-material-extensions==1.2
 packaging==23.1
 paginate==0.5.6


### PR DESCRIPTION
This PR mainly updates the `PyYAML` dependency to fix an issue with Python 3.12 used by GitHub Actions since yesterday (2023-10-26) where the `deploy` workflow can fail when installing the project's required dependencies (in the `Run pip install -r requirements.txt` step):

> Collecting PyYAML==6.0 (from -r requirements.txt (line 29))
> Downloading PyYAML-6.0.tar.gz (124 kB)
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.0/125.0 kB 14.1 MB/s eta 0:00:00
> Installing build dependencies: started
> Installing build dependencies: finished with status 'done'
> Getting requirements to build wheel: started
> Getting requirements to build wheel: finished with status 'error'
> error: subprocess-exited-with-error

✅ The solution is to upgrade PyYAML to 6.0.1 from 6.0 as [suggested here](https://github.com/yaml/pyyaml/issues/756#issuecomment-1751971477)