### PR TITLE
⬆️  Upgrade checkout GH action in CD workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x


### PR DESCRIPTION
This upgrade was missing from PR #39.
The `checkout` action also needs to be upgraded because Node16 is deprecated.
