### PR TITLE
⬆️ Upgrade Dependencies

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,9 @@ extra_javascript:
     - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
+validation:
+    anchors: warn # Check for the existence of anchors present in links
+
 nav:
 - Home: 'index.md'
 - Settings:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ Jinja2==3.1.4
 Markdown==3.5.2
 MarkupSafe==2.1.5
 mergedeep==1.3.4
-mkdocs-htmlproofer-plugin==1.2.0
 mkdocs==1.6.0
 mkdocs-get-deps==0.2.0
+mkdocs-htmlproofer-plugin==1.2.1
 mkdocs-material==9.5.21
 mkdocs-material-extensions==1.3.1
 mkdocs-unused-files==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Babel==2.14.0
+Babel==2.15.0
 beautifulsoup4==4.12.3
 certifi==2024.2.2
 charset-normalizer==3.3.2
@@ -7,7 +7,7 @@ colorama==0.4.6
 ghp-import==2.1.0
 idna==3.7
 Jinja2==3.1.4
-Markdown==3.5.2
+Markdown==3.6
 MarkupSafe==2.1.5
 mergedeep==1.3.4
 mkdocs==1.6.0
@@ -20,8 +20,8 @@ packaging==24.0
 paginate==0.5.6
 pathspec==0.12.1
 platformdirs==4.2.0
-Pygments==2.17.2
-pymdown-extensions==10.7.1
+Pygments==2.18.0
+pymdown-extensions==10.8.1
 python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 pyyaml_env_tag==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pymdown-extensions==10.8.1
 python-dateutil==2.9.0.post0
 PyYAML==6.0.1
 pyyaml_env_tag==0.1
-regex==2023.12.25
+regex==2024.4.28
 requests==2.31.0
 six==1.16.0
 soupsieve==2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mkdocs-unused-files==0.2.0
 packaging==24.0
 paginate==0.5.6
 pathspec==0.12.1
-platformdirs==4.2.0
+platformdirs==4.2.1
 Pygments==2.18.0
 pymdown-extensions==10.8.1
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,10 @@ Jinja2==3.1.4
 Markdown==3.5.2
 MarkupSafe==2.1.5
 mergedeep==1.3.4
-mkdocs==1.5.3
 mkdocs-htmlproofer-plugin==1.2.0
-mkdocs-material==9.5.13
+mkdocs==1.6.0
+mkdocs-get-deps==0.2.0
+mkdocs-material==9.5.21
 mkdocs-material-extensions==1.3.1
 mkdocs-unused-files==0.2.0
 packaging==24.0


### PR DESCRIPTION
Upgrade Project's Dependencies:

- Bump mkdocs to 1.6.0 from 1.5.3
- Bump mkdocs-material to 9.5.21 from 9.5.13
- Bump Babel to 2.15.0 from 2.14.0
- Bump Markdown to 3.6 from 2.5.2
- Bump Pygments to 2.18.0 from 2.17.2
- Bump pymdown-extensions to 10.8.1 from 10.7.1
- Bump mkdocs-htmlproofer-plugin to 1.2.1
- Bump regex to 2024.4.28 from 2023.12.25
- Bump platformdirs to 4.2.1 from 4.2.0
